### PR TITLE
Document X-Forwarded-Proto in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ If you want to serve the application under a basepath and/or with a different in
 * X-Forwarded-Host (ex. `another.domain.com`)
 * X-Forwarded-Path (ex: `/alltube`)
 * X-Forwarded-Port (ex: `5555`)
+* X-Forwarded-Proto (ex: `https`)
 
 ### Apache
 


### PR DESCRIPTION
Alltube respects the `X-Forwarded-Proto` header, but this is not documented in the README. 

closes #367